### PR TITLE
Suggesting changes to ExploreMapSection.js

### DIFF
--- a/src/components/ExploreMapSection.js
+++ b/src/components/ExploreMapSection.js
@@ -20,8 +20,8 @@ const ExploreMapComponent = () => {
 
   // create object of keys that correspond to the emotional attributes and values as their respective labels
   const attributeLabels = {
-    happinessSadness: 'Feeling',
-    calmAnxious: 'Anxious',
+    happinessSadness: 'Happiness', // change to more descriptive term that provides parallel structure
+    calmAnxious: 'Calmness', // change to more descriptive term that provides parallel structure
     awakeTired: 'Alertness',
     safety: 'Safety',
     belonging: 'Belonging'
@@ -235,7 +235,7 @@ const ExploreMapComponent = () => {
               }
             ]
           })
-          mapView.ui.add(legend, 'bottom-left')
+          mapView.ui.add(legend, 'bottom-right') // move legend to bottom-right so it's in line with attribute selection widget
 
           // Add a locate button to the view
           const locateBtn = new Locate({
@@ -304,7 +304,7 @@ const ExploreMapComponent = () => {
       </p>
       <div className='explore-container'>
         <div className='select-container'>
-          <label htmlFor='attribute-select'>Select Emotion:</label>
+          <label htmlFor='attribute-select'>Select Experience Type:</label> {/* Change label to more descriptive term matching the legend title*/}
           <select
             id='attribute-select'
             value={selectedAttribute}


### PR DESCRIPTION
This script was well-organized and easy to follow. Congrats! When I tested the app, my main suggestion is to re-configure the Explore Map section so the legend and attribute selection widget are better aligned. When I first explored this map, it took me a some time to figure out that "Select Emotion" was linked to the legend, both because they are located on either ends of the map and because the title of the attribute selection widget didn't match the legend title. My suggested changes:

1. Move the legend to the bottom-right so it's on the same side of the map as the attribute selection widget. You also might consider placing both of these widgets in the bottom right, with the selection widge stacked just above the legend.
2. Change the title text in the selection widget from "emotion" to "experience type" to better match the legend.
3. Change the names of some attributes to provide for parallel stucture in the list (i.e., happiness, calmness, alertness vs. feeling, anxious, calmness).